### PR TITLE
Added information on Java Applets

### DIFF
--- a/compatibility/html/java-applets.md
+++ b/compatibility/html/java-applets.md
@@ -1,0 +1,20 @@
+When Java Applets were introduced tons of issues were solved. This was before the browser came bundled with a ton of features, browsers were able to render and use apps written in Javascript but due to the popularity of Java the technology took off.
+
+In today's world the situations has changed a bit. Standards like HTML5 are opening up more and more features to the Javascript in the page itself, for example WebUSB and WebGL. This allows developers to build feature rich applications without having to use Java Applets to accomplish certain functions.
+
+With the numerous security issues that have been shown users have either begun uninstalling Java from their systems or keeping as a server language.
+
+This means most of the users hitting your site will not be able to execute Java Applets. Not to mention IOS and Android devices that have never supported Applets officially.
+
+# How do I fix this ?
+
+Avoid using Java Applets for functionality.
+
+To ensure the highest level of usablility remove all Java Applets from a site (this includes ads) and look at using open standards like HTML5. 
+
+HTML5 supports all (if not more) features that a common Java Applet environment provided and works accross all devices from Mobile to Desktop giving websites the largest audience to which they can cater.
+
+# Resources
+
+* [Are java applets a poor choice for new web content?](http://stackoverflow.com/questions/11513367/are-java-applets-a-poor-choice-for-new-web-content)
+* [Java Considered Harmful](https://www.f-secure.com/weblog/archives/00002285.html)


### PR DESCRIPTION
Basic information on why Java Applets are no longer even a option when standards like HTML5 exist. 